### PR TITLE
Added the functionality to plot histogram showing the exposure of any ticker and greek

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# plots saved by gnuplot
+plots/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ tt pf (portfolio)      view and close positions, check margin and analyze BP usa
 tt trade               buy or sell stocks/ETFs, crypto, and futures
 tt order               view, replace, and cancel orders
 tt plot                plot charts directly in the terminal! requires `gnuplot` installed
+tt plot gamma          plots the gamma exposure of any given ticker for any expiration, it can also do vanna, charm and delta greeks 
 tt wl (watchlist)      view prices and metrics for symbols in your watchlists
 ```
 For more options, run `tt --help` or `tt <subcommand> --help`.

--- a/ttcli/modules/calc.py
+++ b/ttcli/modules/calc.py
@@ -1,0 +1,412 @@
+import numpy as np
+from ttcli.modules import stats
+
+async def calc_exposures(
+    option_data,
+    ticker,
+    expir,
+    first_expiry,
+    this_monthly_opex,
+    spot_price,
+    today_ddt,
+    today_ddt_string,
+    SOFR_yield,
+    dividend_yield
+):
+    dividend_yield = dividend_yield
+    risk_free_yield = SOFR_yield
+
+    monthly_options_dates = [first_expiry, this_monthly_opex]
+
+    strike_prices = option_data["strike_price"].to_numpy()
+    expirations = option_data["expiration_date"].to_numpy()
+    time_till_exp = option_data["time_till_exp"].to_numpy()
+    opt_call_ivs = option_data["call_iv"].to_numpy()
+    opt_put_ivs = option_data["put_iv"].to_numpy()
+    call_open_interest = option_data["call_open_int"].to_numpy()
+    put_open_interest = option_data["put_open_int"].to_numpy()
+
+    nonzero_call_cond = (time_till_exp > 0) & (opt_call_ivs > 0)
+    nonzero_put_cond = (time_till_exp > 0) & (opt_put_ivs > 0)
+    np_spot_price = np.array([[spot_price]])
+
+    call_dp, call_cdf_dp, call_pdf_dp = stats.calc_dp_cdf_pdf(
+        np_spot_price,
+        strike_prices,
+        opt_call_ivs,
+        time_till_exp,
+        risk_free_yield,
+        dividend_yield,
+    )
+    put_dp, put_cdf_dp, put_pdf_dp = stats.calc_dp_cdf_pdf(
+        np_spot_price,
+        strike_prices,
+        opt_put_ivs,
+        time_till_exp,
+        risk_free_yield,
+        dividend_yield,
+    )
+
+    from_strike = 0.5 * spot_price
+    to_strike = 1.5 * spot_price
+
+    # ---=== CALCULATE EXPOSURES ===---
+    option_data["call_dex"] = (
+        option_data["call_delta"].to_numpy() * call_open_interest * spot_price
+    )
+    option_data["put_dex"] = (
+        option_data["put_delta"].to_numpy() * put_open_interest * spot_price
+    )
+    option_data["call_gex"] = (
+        option_data["call_gamma"].to_numpy()
+        * call_open_interest
+        * spot_price
+        * spot_price
+    )
+    option_data["put_gex"] = (
+        option_data["put_gamma"].to_numpy()
+        * put_open_interest
+        * spot_price
+        * spot_price
+        * -1
+    )
+    option_data["call_vex"] = np.where(
+        nonzero_call_cond,
+        stats.calc_vanna_ex(
+            np_spot_price,
+            opt_call_ivs,
+            time_till_exp,
+            dividend_yield,
+            call_open_interest,
+            call_dp,
+            call_pdf_dp,
+        )[0],
+        0,
+    )
+    option_data["put_vex"] = np.where(
+        nonzero_put_cond,
+        stats.calc_vanna_ex(
+            np_spot_price,
+            opt_put_ivs,
+            time_till_exp,
+            dividend_yield,
+            put_open_interest,
+            put_dp,
+            put_pdf_dp,
+        )[0],
+        0,
+    )
+    option_data["call_cex"] = np.where(
+        nonzero_call_cond,
+        stats.calc_charm_ex(
+            np_spot_price,
+            opt_call_ivs,
+            time_till_exp,
+            risk_free_yield,
+            dividend_yield,
+            "call",
+            call_open_interest,
+            call_dp,
+            call_cdf_dp,
+            call_pdf_dp,
+        )[0],
+        0,
+    )
+    option_data["put_cex"] = np.where(
+        nonzero_put_cond,
+        stats.calc_charm_ex(
+            np_spot_price,
+            opt_put_ivs,
+            time_till_exp,
+            risk_free_yield,
+            dividend_yield,
+            "put",
+            put_open_interest,
+            put_dp,
+            put_cdf_dp,
+            put_pdf_dp,
+        )[0],
+        0,
+    )
+    # Calculate total and scale down
+    option_data["total_delta"] = (
+        option_data["call_dex"].to_numpy() + option_data["put_dex"].to_numpy()
+    ) / 10**9
+    option_data["total_gamma"] = (
+        option_data["call_gex"].to_numpy() + option_data["put_gex"].to_numpy()
+    ) / 10**9
+    option_data["total_vanna"] = (
+        option_data["call_vex"].to_numpy() - option_data["put_vex"].to_numpy()
+    ) / 10**9
+    option_data["total_charm"] = (
+        option_data["call_cex"].to_numpy() - option_data["put_cex"].to_numpy()
+    ) / 10**9
+
+    # group all options by strike / expiration then average their IVs
+    df_agg_strike_mean = (
+        option_data[["strike_price", "call_iv", "put_iv"]]
+        .groupby(["strike_price"])
+        .mean(numeric_only=True)
+    )
+    df_agg_exp_mean = (
+        option_data[["expiration_date", "call_iv", "put_iv"]]
+        .groupby(["expiration_date"])
+        .mean(numeric_only=True)
+    )
+    # filter strikes / expirations for relevance
+    df_agg_strike_mean = df_agg_strike_mean[from_strike:to_strike]
+    # df_agg_exp_mean = df_agg_exp_mean[: today_ddt + timedelta(weeks=52)]
+
+    call_ivs = {
+        "strike": df_agg_strike_mean["call_iv"].to_numpy(),
+        "exp": df_agg_exp_mean["call_iv"].to_numpy(),
+    }
+    put_ivs = {
+        "strike": df_agg_strike_mean["put_iv"].to_numpy(),
+        "exp": df_agg_exp_mean["put_iv"].to_numpy(),
+    }
+
+    # ---=== CALCULATE EXPOSURE PROFILES ===---
+    levels = np.linspace(from_strike, to_strike, 300).reshape(-1, 1)
+
+    totaldelta = {
+        "all": np.array([]),
+        "ex_next": np.array([]),
+        "ex_fri": np.array([]),
+    }
+    totalgamma = {
+        "all": np.array([]),
+        "ex_next": np.array([]),
+        "ex_fri": np.array([]),
+    }
+    totalvanna = {
+        "all": np.array([]),
+        "ex_next": np.array([]),
+        "ex_fri": np.array([]),
+    }
+    totalcharm = {
+        "all": np.array([]),
+        "ex_next": np.array([]),
+        "ex_fri": np.array([]),
+    }
+
+    # For each spot level, calculate greek exposure at that point
+    call_dp, call_cdf_dp, call_pdf_dp = stats.calc_dp_cdf_pdf(
+        levels,
+        strike_prices,
+        opt_call_ivs,
+        time_till_exp,
+        risk_free_yield,
+        dividend_yield,
+    )
+    put_dp, put_cdf_dp, put_pdf_dp = stats.calc_dp_cdf_pdf(
+        levels,
+        strike_prices,
+        opt_put_ivs,
+        time_till_exp,
+        risk_free_yield,
+        dividend_yield,
+    )
+    call_delta_ex = np.where(
+        nonzero_call_cond,
+        stats.calc_delta_ex(
+            levels,
+            time_till_exp,
+            dividend_yield,
+            "call",
+            call_open_interest,
+            call_cdf_dp,
+        ),
+        0,
+    )
+    put_delta_ex = np.where(
+        nonzero_put_cond,
+        stats.calc_delta_ex(
+            levels,
+            time_till_exp,
+            dividend_yield,
+            "put",
+            put_open_interest,
+            put_cdf_dp,
+        ),
+        0,
+    )
+    call_gamma_ex = np.where(
+        nonzero_call_cond,
+        stats.calc_gamma_ex(
+            levels,
+            opt_call_ivs,
+            time_till_exp,
+            dividend_yield,
+            call_open_interest,
+            call_pdf_dp,
+        ),
+        0,
+    )
+    put_gamma_ex = np.where(
+        nonzero_put_cond,
+        stats.calc_gamma_ex(
+            levels,
+            opt_put_ivs,
+            time_till_exp,
+            dividend_yield,
+            put_open_interest,
+            put_pdf_dp,
+        ),
+        0,
+    )
+    call_vanna_ex = np.where(
+        nonzero_call_cond,
+        stats.calc_vanna_ex(
+            levels,
+            opt_call_ivs,
+            time_till_exp,
+            dividend_yield,
+            call_open_interest,
+            call_dp,
+            call_pdf_dp,
+        ),
+        0,
+    )
+    put_vanna_ex = np.where(
+        nonzero_put_cond,
+        stats.calc_vanna_ex(
+            levels,
+            opt_put_ivs,
+            time_till_exp,
+            dividend_yield,
+            put_open_interest,
+            put_dp,
+            put_pdf_dp,
+        ),
+        0,
+    )
+    call_charm_ex = np.where(
+        nonzero_call_cond,
+        stats.calc_charm_ex(
+            levels,
+            opt_call_ivs,
+            time_till_exp,
+            risk_free_yield,
+            dividend_yield,
+            "call",
+            call_open_interest,
+            call_dp,
+            call_cdf_dp,
+            call_pdf_dp,
+        ),
+        0,
+    )
+    put_charm_ex = np.where(
+        nonzero_put_cond,
+        stats.calc_charm_ex(
+            levels,
+            opt_put_ivs,
+            time_till_exp,
+            risk_free_yield,
+            dividend_yield,
+            "put",
+            put_open_interest,
+            put_dp,
+            put_cdf_dp,
+            put_pdf_dp,
+        ),
+        0,
+    )
+
+    # delta exposure
+    totaldelta["all"] = (call_delta_ex.sum(axis=1) + put_delta_ex.sum(axis=1)) / 10**9
+    # gamma exposure
+    totalgamma["all"] = (call_gamma_ex.sum(axis=1) - put_gamma_ex.sum(axis=1)) / 10**9
+    # vanna exposure
+    totalvanna["all"] = (call_vanna_ex.sum(axis=1) - put_vanna_ex.sum(axis=1)) / 10**9
+    # charm exposure
+    totalcharm["all"] = (call_charm_ex.sum(axis=1) - put_charm_ex.sum(axis=1)) / 10**9
+
+    expirs_next_expiry = expirations == first_expiry
+    expirs_up_to_monthly_opex = expirations <= this_monthly_opex
+    if expir != "0dte":
+        # exposure for next expiry
+        totaldelta["ex_next"] = (
+            np.where(expirs_next_expiry, call_delta_ex, 0).sum(axis=1)
+            + np.where(expirs_next_expiry, put_delta_ex, 0).sum(axis=1)
+        ) / 10**9
+        totalgamma["ex_next"] = (
+            np.where(expirs_next_expiry, call_gamma_ex, 0).sum(axis=1)
+            - np.where(expirs_next_expiry, put_gamma_ex, 0).sum(axis=1)
+        ) / 10**9
+        totalvanna["ex_next"] = (
+            np.where(expirs_next_expiry, call_vanna_ex, 0).sum(axis=1)
+            - np.where(expirs_next_expiry, put_vanna_ex, 0).sum(axis=1)
+        ) / 10**9
+        totalcharm["ex_next"] = (
+            np.where(expirs_next_expiry, call_charm_ex, 0).sum(axis=1)
+            - np.where(expirs_next_expiry, put_charm_ex, 0).sum(axis=1)
+        ) / 10**9
+        if expir == "all":
+            # exposure for next monthly opex
+            totaldelta["ex_fri"] = (
+                np.where(expirs_up_to_monthly_opex, call_delta_ex, 0).sum(axis=1)
+                + np.where(expirs_up_to_monthly_opex, put_delta_ex, 0).sum(axis=1)
+            ) / 10**9
+            totalgamma["ex_fri"] = (
+                np.where(expirs_up_to_monthly_opex, call_gamma_ex, 0).sum(axis=1)
+                - np.where(expirs_up_to_monthly_opex, put_gamma_ex, 0).sum(axis=1)
+            ) / 10**9
+            totalvanna["ex_fri"] = (
+                np.where(expirs_up_to_monthly_opex, call_vanna_ex, 0).sum(axis=1)
+                - np.where(expirs_up_to_monthly_opex, put_vanna_ex, 0).sum(axis=1)
+            ) / 10**9
+            totalcharm["ex_fri"] = (
+                np.where(expirs_up_to_monthly_opex, call_charm_ex, 0).sum(axis=1)
+                - np.where(expirs_up_to_monthly_opex, put_charm_ex, 0).sum(axis=1)
+            ) / 10**9
+
+    # Find Delta Flip Point
+    zero_cross_idx = np.where(np.diff(np.sign(totaldelta["all"])))[0]
+    neg_delta = totaldelta["all"][zero_cross_idx]
+    pos_delta = totaldelta["all"][zero_cross_idx + 1]
+    neg_strike = levels[zero_cross_idx]
+    pos_strike = levels[zero_cross_idx + 1]
+    zerodelta = pos_strike - (
+        (pos_strike - neg_strike) * pos_delta / (pos_delta - neg_delta)
+    )
+    # Find Gamma Flip Point
+    zero_cross_idx = np.where(np.diff(np.sign(totalgamma["all"])))[0]
+    negGamma = totalgamma["all"][zero_cross_idx]
+    posGamma = totalgamma["all"][zero_cross_idx + 1]
+    neg_strike = levels[zero_cross_idx]
+    pos_strike = levels[zero_cross_idx + 1]
+    zerogamma = pos_strike - (
+        (pos_strike - neg_strike) * posGamma / (posGamma - negGamma)
+    )
+
+    if zerodelta.size > 0:
+        zerodelta = zerodelta[0][0]
+    else:
+        zerodelta = 0
+        print("delta flip not found for", ticker, expir, "probably error downloading data")
+    if zerogamma.size > 0:
+        zerogamma = zerogamma[0][0]
+    else:
+        zerogamma = 0
+        print("gamma flip not found for", ticker, expir, "probably error downloading data")
+
+    return (
+        option_data,
+        today_ddt,
+        today_ddt_string,
+        monthly_options_dates,
+        spot_price,
+        from_strike,
+        to_strike,
+        levels.ravel(),
+        totaldelta,
+        totalgamma,
+        totalvanna,
+        totalcharm,
+        zerodelta,
+        zerogamma,
+        call_ivs,
+        put_ivs,
+    )

--- a/ttcli/modules/stats.py
+++ b/ttcli/modules/stats.py
@@ -1,0 +1,121 @@
+import numpy as np
+import ctypes
+from math import tau
+from numba import vectorize, njit
+from numba.types import float64, UniTuple, string
+from numba.extending import get_cython_function_address
+
+
+addr = get_cython_function_address("scipy.special.cython_special", "__pyx_fuse_1erf")
+functype = ctypes.CFUNCTYPE(ctypes.c_double, ctypes.c_double)
+erf_fn = functype(addr)
+
+
+@vectorize([float64(float64)])
+def vec_erf(x):
+    return erf_fn(x)
+
+
+@njit(float64[:, :](float64[:, :]))
+def erf_njit(x):
+    return vec_erf(x)
+
+
+# Probability density function for a normal distribution
+@njit(float64[:, :](float64[:, :], float64, float64))
+def norm_pdf(x, mu, sigma):
+    variance = sigma**2.0
+    return np.exp((x - mu) ** 2.0 / (-2.0 * variance)) / np.sqrt(tau * variance)
+
+
+# Cumulative distribution function for a normal distribution
+@njit(float64[:, :](float64[:, :], float64, float64))
+def norm_cdf(x, mu, sigma):
+    return 0.5 * (1.0 + erf_njit((x - mu) / (sigma * np.sqrt(2.0))))
+
+
+# S is spot price, K is strike price, vol is implied volatility
+# T is time to expiration, r is risk-free rate, q is dividend yield
+@njit(
+    UniTuple(float64[:, :], 3)(
+        float64[:, :], float64[:], float64[:], float64[:], float64, float64
+    )
+)
+def calc_dp_cdf_pdf(S, K, vol, T, r, q):
+    dp = (np.log(S / K) + (r - q + 0.5 * vol**2) * T) / (vol * np.sqrt(T))
+    cdf_dp = norm_cdf(dp, 0.0, 1.0)
+    pdf_dp = norm_pdf(dp, 0.0, 1.0)
+    return dp, cdf_dp, pdf_dp
+
+
+# Black-Scholes Pricing Formula
+
+
+@njit(
+    float64[:, :](float64[:, :], float64[:], float64, string, float64[:], float64[:, :])
+)
+def calc_delta_ex(S, T, q, opt_type, OI, cdf_dp):
+    if opt_type == "call":
+        delta = np.exp(-q * T) * cdf_dp
+    else:
+        delta = -np.exp(-q * T) * (1 - cdf_dp)
+    # change in option price per one percent move in underlying
+    return delta * OI * S
+
+
+@njit(
+    float64[:, :](
+        float64[:, :], float64[:], float64[:], float64, float64[:], float64[:, :]
+    )
+)
+def calc_gamma_ex(S, vol, T, q, OI, pdf_dp):
+    gamma = np.exp(-q * T) * pdf_dp / (S * vol * np.sqrt(T))
+    # change in delta per one percent move in underlying
+    return gamma * OI * S * S  # Gamma is same formula for calls and puts
+
+
+@njit(
+    float64[:, :](
+        float64[:, :],
+        float64[:],
+        float64[:],
+        float64,
+        float64[:],
+        float64[:, :],
+        float64[:, :],
+    )
+)
+def calc_vanna_ex(S, vol, T, q, OI, dp, pdf_dp):
+    dm = dp - vol * np.sqrt(T)
+    vanna = -np.exp(-q * T) * pdf_dp * (dm / vol)
+    # change in delta per one percent move in IV
+    # or change in vega per one percent move in underlying
+    return vanna * OI * S * vol  # Vanna is same formula for calls and puts
+
+
+@njit(
+    float64[:, :](
+        float64[:, :],
+        float64[:],
+        float64[:],
+        float64,
+        float64,
+        string,
+        float64[:],
+        float64[:, :],
+        float64[:, :],
+        float64[:, :],
+    )
+)
+def calc_charm_ex(S, vol, T, r, q, opt_type, OI, dp, cdf_dp, pdf_dp):
+    dm = dp - vol * np.sqrt(T)
+    if opt_type == "call":
+        charm = (q * np.exp(-q * T) * cdf_dp) - np.exp(-q * T) * pdf_dp * (
+            2 * (r - q) * T - dm * vol * np.sqrt(T)
+        ) / (2 * T * vol * np.sqrt(T))
+    else:
+        charm = (-q * np.exp(-q * T) * (1 - cdf_dp)) - np.exp(-q * T) * pdf_dp * (
+            2 * (r - q) * T - dm * vol * np.sqrt(T)
+        ) / (2 * T * vol * np.sqrt(T))
+    # change in delta per day until expiration
+    return charm * OI * S * T

--- a/ttcli/option.py
+++ b/ttcli/option.py
@@ -1,5 +1,6 @@
 import asyncio
-from datetime import datetime
+from collections import defaultdict
+from datetime import datetime, date, timedelta
 from decimal import Decimal
 from typing import Annotated
 
@@ -8,6 +9,7 @@ from rich.console import Console
 from rich.table import Table
 from tastytrade import DXLinkStreamer
 from tastytrade.dxfeed import Greeks, Quote, Summary, Trade
+from tastytrade.metrics import MarketMetricInfo, get_market_metrics
 from tastytrade.instruments import (
     Future,
     FutureOption,
@@ -30,6 +32,13 @@ from tastytrade.utils import TastytradeError, get_tasty_monthly
 from typer import Option
 from yaspin import yaspin
 
+from ttcli.modules.calc import calc_exposures
+from pygnuplot.gnuplot import Gnuplot
+import pandas as pd
+import numpy as np
+from zoneinfo import ZoneInfo
+
+
 from ttcli.utils import (
     ZERO,
     AsyncTyper,
@@ -42,6 +51,10 @@ from ttcli.utils import (
     print_error,
     print_warning,
     round_to_tick_size,
+    is_third_friday,
+    get_SOFR_ticker,
+    next_open_day,
+    expir_to_datetime
 )
 
 
@@ -55,12 +68,8 @@ def choose_expiration(
     else:
         exps = [e for e in chain.expirations if is_monthly(e.expiration_date)]
     if dte is not None:
-        return min(
-            exps,
-            key=lambda exp: abs(
-                (exp.expiration_date - datetime.now().date()).days - dte
-            ),
-        )
+        return exps[dte]
+    
     exps.sort(key=lambda e: e.expiration_date)
     tasty_monthly = get_tasty_monthly()
     default = exps[0]
@@ -92,10 +101,7 @@ def choose_futures_expiration(
     else:
         exps = [e for e in subchain.expirations if e.expiration_type != "Weekly"]
     if dte is not None:
-        return min(
-            exps,
-            key=lambda exp: abs(exp.days_to_expiration - dte),
-        )
+        return exps[dte]
     exps.sort(key=lambda e: e.expiration_date)
     # find closest to 45 DTE
     default = min(exps, key=lambda e: abs(e.days_to_expiration - 45))
@@ -1069,3 +1075,190 @@ async def chain(
         table.add_row(*(prepend + row), end_section=(i == mid_index - 1))
 
     console.print(table)
+
+async def get_futures_price(sesh, symbol):
+    is_future = symbol[0] == "/"
+    if is_future:
+        future = Future.get(sesh, symbol)
+    async with DXLinkStreamer(sesh) as streamer:
+        if is_future:
+            await streamer.subscribe(Trade, [future.streamer_symbol])
+        
+        trade = await streamer.get_event(Trade)
+        return trade.price
+
+async def fetch_chain_for_dte(sesh, symbol, strikes, dte, weeklies=True):
+    # Makes a DataFrame of options for one DTE, only one date 
+    is_future = symbol[0] == "/"
+    if is_future:
+        chain = NestedFutureOptionChain.get(sesh, symbol)
+        subchain = choose_futures_expiration(chain, dte, weeklies)
+        ticks = subchain.tick_sizes
+    else:
+        chain = NestedOptionChain.get(sesh, symbol)[0]
+        subchain = choose_expiration(chain, dte, weeklies)
+        ticks = chain.tick_sizes
+    fmt = lambda x: round_to_tick_size(x, ticks)
+
+    # Spot price
+    async with DXLinkStreamer(sesh) as streamer:
+        if is_future:
+            future = Future.get(sesh, subchain.underlying_symbol)
+            await streamer.subscribe(Trade, [future.streamer_symbol])
+        else:
+            await streamer.subscribe(Trade, [symbol])
+        trade = await streamer.get_event(Trade)
+
+        # Choose strikes
+        subchain.strikes.sort(key=lambda s: s.strike_price)
+        mid_index = 0
+        if strikes < len(subchain.strikes):
+            while subchain.strikes[mid_index].strike_price < trade.price:
+                mid_index += 1
+            half = strikes // 2
+            all_strikes = subchain.strikes[mid_index - half : mid_index + half]
+        else:
+            all_strikes = subchain.strikes
+
+        dxfeeds = [s.call_streamer_symbol for s in all_strikes] + [
+            s.put_streamer_symbol for s in all_strikes
+        ]
+
+    
+        tasks = [
+            asyncio.create_task(listen_events(dxfeeds, Greeks, streamer)),
+            asyncio.create_task(listen_events(dxfeeds, Summary, streamer)),
+        ]
+        await asyncio.gather(*tasks)
+        greeks_dict = tasks[0].result()
+        summary_dict = tasks[1].result()
+
+
+    # Create the dataframe
+    data_rows = []
+    expiration = pd.Timestamp(subchain.expiration_date).tz_localize("America/New_York")
+
+    for strike in all_strikes:
+        call_greek = greeks_dict.get(strike.call_streamer_symbol)
+        put_greek = greeks_dict.get(strike.put_streamer_symbol)
+        call_summary = summary_dict.get(strike.call_streamer_symbol)
+        put_summary = summary_dict.get(strike.put_streamer_symbol)
+
+        data_rows.append({
+            "strike_price": fmt(strike.strike_price),
+            "expiration_date": expiration,
+            "calls": strike.call,
+            "call_iv": float(call_greek.volatility) if call_greek else None,
+            "call_open_int": call_summary.open_interest if call_summary else None,
+            "call_delta": float(call_greek.delta) if call_greek else None,
+            "call_gamma": float(call_greek.gamma) if call_greek else None,
+            "puts": strike.put,
+            "put_iv": float(put_greek.volatility) if put_greek else None,
+            "put_open_int": put_summary.open_interest if put_summary else None,
+            "put_delta": float(put_greek.delta) if put_greek else None,
+            "put_gamma": float(put_greek.gamma) if put_greek else None,
+        })
+
+    df = pd.DataFrame(data_rows)
+    today = date.today()
+    exp_dates = pd.to_datetime(df["expiration_date"].dt.tz_localize(None)).values.astype("datetime64[D]")    
+    busday_counts = np.busday_count(today, exp_dates)
+
+    df["time_till_exp"] = np.where(busday_counts == 0, 1 / 252, busday_counts / 252)
+
+    df = df.sort_values(by=["expiration_date", "strike_price"]).reset_index(drop=True)
+    return df, trade.price
+
+
+async def chain_data_df(
+    symbol: str,
+    strikes: Annotated[int | None, Option("--strikes", "-s")] = None,
+    dte: Annotated[int | None, Option("--dte")] = None,
+    greek: str = "gamma",
+    save: Annotated[bool, Option("--save", "-S", is_flag=True, help="Save the generated data")] = False
+):
+    weeklies = True
+    sesh = RenewableSession()
+    symbol = symbol.upper()
+
+    spot_price = 0
+    SOFRrate = 0
+
+    if strikes is None:
+        strikes = sesh.config.getint("option", "strike-count", fallback=50)
+
+    if dte is None:
+        return await fetch_chain_for_dte(sesh, symbol, strikes, None, weeklies)
+    else:
+        # Recursively keep loading the data from DTE, then DTE - 1, then DTE - 2, and so on till DTE == 0
+        all_dfs = []
+        total = dte + 1  # total number of DTEs to load
+
+        with yaspin(color="green", text=f"Fetching option chains for {symbol}...") as spinner:
+            for i, d in enumerate(range(dte, -1, -1), start=1):
+                spinner.text = f"Fetching DTE={d} ({i}/{total})..."
+                try:
+                    df, spot_price = await fetch_chain_for_dte(sesh, symbol, strikes, d, weeklies)
+                    all_dfs.append(df)
+                except Exception as e:
+                    spinner.write(f"⚠️ Error fetching DTE={d}: {e}")
+                    continue
+
+            if all_dfs:
+                spinner.ok("Done, no errors")
+                option_data = pd.concat(all_dfs, ignore_index=True)
+            else:
+                spinner.fail("No data retrieved, error")
+                option_data = pd.DataFrame()
+
+    option_data["expiration_date"] = pd.to_datetime(option_data["expiration_date"])
+    
+    first_expiry = option_data["expiration_date"].min()
+    expir = option_data["expiration_date"].max()
+    tz = ZoneInfo("America/New_York")
+    today_ddt = pd.Timestamp.now(tz=tz)
+    today_ddt_string = today_ddt.strftime("%Y %b %d, %I:%M %p %Z")
+    this_monthly_opex, _ = is_third_friday(first_expiry, "America/New_York")
+    dividend_yield = 0
+    SOFRrate = await get_futures_price(sesh, get_SOFR_ticker())
+    SOFR_yield = float((100 - SOFRrate)/100)
+    list_tickers = [symbol]
+    metrics = get_market_metrics(sesh, list_tickers)
+    metrics_dict = defaultdict(
+            lambda: MarketMetricInfo(
+                symbol="", market_cap=ZERO, updated_at=datetime.now()
+            )
+        )
+    metrics_dict.update({m.symbol: m for m in metrics})
+    for key in metrics_dict.keys():
+        metric = metrics_dict[key]
+        dividend_yield = metric.dividend_yield
+
+    option_data["strike_price"] = option_data["strike_price"].apply(float)
+    option_data["strike_price"] = option_data["strike_price"].to_numpy(dtype=np.float64)
+    option_data["call_open_int"] = option_data["call_open_int"].astype(np.float64)
+    option_data["put_open_int"] = option_data["put_open_int"].astype(np.float64)
+    spot_price = float(spot_price)
+    SOFR_yield = float(SOFR_yield)
+    if dividend_yield:
+        dividend_yield = float(dividend_yield)
+    else:
+        dividend_yield = float(0)
+    expir = str(dte) + "dte"
+    exposure_data = await calc_exposures(option_data,
+          symbol,
+          expir,
+          first_expiry,
+          this_monthly_opex,
+          spot_price,
+          today_ddt,
+          today_ddt_string,
+          SOFR_yield,
+          dividend_yield
+    )
+    lower_strike = float(option_data["strike_price"].min())
+    upper_strike = float(option_data["strike_price"].max())
+    greek_filter = greek
+    exposure_data = exposure_data + (expir,symbol,lower_strike, upper_strike, greek_filter, save)
+    return exposure_data
+

--- a/ttcli/plot.py
+++ b/ttcli/plot.py
@@ -1,4 +1,4 @@
-import os
+import os, sys
 import shutil
 import tempfile
 from datetime import datetime, time, timedelta
@@ -14,6 +14,13 @@ from typer import Option
 from yaspin import yaspin
 
 from ttcli.utils import AsyncTyper, RenewableSession, print_error
+from ttcli.option import chain_data_df
+
+
+import pandas as pd
+import numpy as np
+from zoneinfo import ZoneInfo
+import shutil, tempfile, os
 
 plot = AsyncTyper(help="Plot candle charts for any symbol.", no_args_is_help=True)
 fmt = "%Y-%m-%d %H:%M:%S"
@@ -46,11 +53,12 @@ def get_start_time(width: CandleType) -> datetime:
         start_day = valid_days[0].date()
     else:
         valid_days = NYSE.valid_days(today - timedelta(days=5), end).to_pydatetime()  # type: ignore
+        # make the index here [0] so it shows and loads last five days and not only today
         start_day = valid_days[-1].date()
     return datetime.combine(start_day, time(9, 30), TZ)
 
 
-def gnuplot(sesh: RenewableSession, symbol: str, candles: list[str]) -> None:
+def gnuplot(sesh: RenewableSession, symbol: str, candles: list[str], save: bool) -> None:
     if not shutil.which("gnuplot"):
         print_error(
             "Please install gnuplot on your system to use the plot module: "
@@ -72,8 +80,17 @@ def gnuplot(sesh: RenewableSession, symbol: str, candles: list[str]) -> None:
     last_padded = (last_dt + padding).strftime(fmt)
     font = sesh.config.get("plot", "font", fallback="Courier New")
     font_size = sesh.config.getint("plot", "font-size", fallback=11)
+    
+    if sys.platform == "win32":
+        terminal = "sixel size 1024,768"
+        clear = "cls"
+        
+    elif sys.platform == "linux" or sys.platform == "darwin":
+        terminal = f"kittycairo transparent font '{font},{font_size}'"
+        clear = "clear"
+
     gnu.set(
-        terminal=f"kittycairo transparent font '{font},{font_size}'",
+        terminal=terminal,
         xdata="time",
         timefmt=f'"{fmt}"',
         xrange=f'["{first_padded}":"{last_padded}"]',
@@ -89,13 +106,361 @@ def gnuplot(sesh: RenewableSession, symbol: str, candles: list[str]) -> None:
         ytics="nomirror textcolor rgb 'white' scale 0",
     )
     gnu.unset("colorbox")
-    os.system("clear")
+    os.system(clear)
     gnu.plot(
         f"'{tmp.name}' using (strptime('{fmt}', strcol(1))):2:4:3:5:($5 < $2 ? -1 : 1) with candlesticks palette notitle"
     )
-    _ = input()
-    os.system("clear")
 
+    PLOT_DIR = "plots"
+    timestamp = datetime.now(ZoneInfo("America/New_York")).strftime("%Y%m%d_%H%M%S")
+    filename = f"{PLOT_DIR}/{symbol}/{timestamp}.png"
+
+    if save:
+        # Save as PNG
+        os.makedirs(os.path.dirname(filename), exist_ok=True)
+        gnu.cmd(f"set terminal pngcairo size 1200,800 enhanced font 'Sans,12' background rgb 'black'")
+        gnu.cmd(f"set output '{filename}'")
+        gnu.plot(
+                f"'{tmp.name}' using (strptime('{fmt}', strcol(1))):2:4:3:5:($5 < $2 ? -1 : 1) with candlesticks palette notitle"
+            )        
+        gnu.cmd("set output")  # close and save
+        print("Plot saved in: ", filename)
+    _ = input()
+    os.system(clear)
+
+
+def gnu_plot_greeks_histogram(
+        df,
+        today_ddt,
+        today_ddt_string,
+        monthly_options_dates,
+        spot_price,
+        from_strike,
+        to_strike,
+        levels,
+        totaldelta,
+        totalgamma,
+        totalvanna,
+        totalcharm,
+        zerodelta,
+        zerogamma,
+        call_ivs,
+        put_ivs,
+        exp, 
+        ticker,
+        lower_bound,
+        upper_bound,
+        greek_filter = None,
+        save = False
+
+):
+
+    if not isinstance(df, pd.DataFrame) or df.empty:
+        return None
+
+    filenames = []    
+    GREEKS = [greek_filter] if greek_filter else ["delta", "gamma", "vanna", "charm"]
+    VISUALIZATIONS = {
+    "delta": ["Absolute Delta Exposure", "Delta Exposure By Calls/Puts", "Delta Exposure Profile"],
+    "gamma": ["Absolute Gamma Exposure", "Gamma Exposure By Calls/Puts", "Gamma Exposure Profile"],
+    "vanna": ["Absolute Vanna Exposure", "Implied Volatility Average", "Vanna Exposure Profile"],
+    "charm": ["Absolute Charm Exposure", "Charm Exposure Profile"],
+    }
+    PLOT_DIR = "plots"
+    timestamp = datetime.now(ZoneInfo("America/New_York")).strftime("%Y%m%d_%H%M%S")
+    
+    if sys.platform == "win32":
+        terminal = "sixel size 1024,768"
+        clear = "cls"
+        
+    elif sys.platform == "linux" or sys.platform == "darwin":
+        terminal = f"kittycairo transparent font '{font},{font_size}'"
+        clear = "clear"
+
+    for greek in GREEKS:
+        for value in VISUALIZATIONS[greek]:
+            try:
+                
+                date_condition = not "Profile" in value
+                if date_condition:
+                    if not isinstance(from_strike, (int, float)) or not isinstance(to_strike, (int, float)):
+                        print("Invalid: ", greek, value)
+                        continue
+                    df_agg = df.groupby(["strike_price"]).sum(numeric_only=True)
+                    strikes_sorted = np.sort(df_agg.index.values)
+                    strike_steps = np.diff(strikes_sorted)
+                    if len(strike_steps) == 0:
+                        step = 1  # fallback in case of just one strike
+                    else:
+                        step = np.min(strike_steps[strike_steps > 0])
+                    
+                    lower_strike = max(np.floor(lower_bound / step) * step, df_agg.index.min())
+                    upper_strike = min(np.ceil(upper_bound / step) * step, df_agg.index.max())
+                    strikes = np.arange(lower_strike, upper_strike + step, step)
+                    df_agg = df_agg.reindex(strikes, method='ffill').fillna(0)
+                    if df_agg.empty:
+                        continue
+                else:
+                    df_agg = df.groupby(["expiration_date"]).sum(numeric_only=True)
+                    if df_agg.empty:
+                        continue
+
+                if "Calls/Puts" in value or value == "Implied Volatility Average":
+                    key = "strike" if date_condition else "exp"
+                    if not (isinstance(call_ivs, dict) and isinstance(put_ivs, dict) and
+                            key in call_ivs and key in put_ivs):
+                        continue
+                    call_ivs_data, put_ivs_data = call_ivs[key], put_ivs[key]
+                else:
+                    call_ivs_data, put_ivs_data = None, None
+
+
+                name = value.split()[1] if "Absolute" in value else value.split()[0]
+                
+                if "Absolute" in value:
+                    filename = f"{PLOT_DIR}/{ticker}/{exp}/{greek}/{value.replace(' ', '_')}/{timestamp}.png"
+                    agg_by_strike = df_agg[f"total_{name.lower()}"]
+                    
+                    max_positive_strike = agg_by_strike.idxmax()
+                    max_negative_strike = agg_by_strike.idxmin()
+                    
+                    # Find the transition point from positive to negative that it's close to the spot_price, ignore outliers
+                    signs = np.sign(agg_by_strike.values)
+
+                    # Find same sign
+                    runs = []
+                    if len(signs) > 0:
+                        current_sign = signs[0]
+                        start = 0
+                        for j in range(1, len(signs)):
+                            if signs[j] != current_sign:
+                                runs.append((current_sign, start, j-1))
+                                current_sign = signs[j]
+                                start = j
+                        runs.append((current_sign, start, len(signs)-1))
+
+                    # Find valid transitions of sign
+                    zero_strikes = []
+                    for r in range(1, len(runs)):
+                        prev_run = runs[r-1]
+                        curr_run = runs[r]
+                        prev_len = prev_run[2] - prev_run[1] + 1
+                        curr_len = curr_run[2] - curr_run[1] + 1
+                        if prev_len >= 2 and curr_len >= 2 and prev_run[0] != curr_run[0] and prev_run[0] != 0 and curr_run[0] != 0:
+                            idx1 = prev_run[2]
+                            idx2 = curr_run[1]
+                            strike1 = agg_by_strike.index[idx1]
+                            value1 = agg_by_strike.iloc[idx1]
+                            strike2 = agg_by_strike.index[idx2]
+                            value2 = agg_by_strike.iloc[idx2]
+                            # Interpolate the position of the zero strike
+                            zero_strike = strike2 - ((strike2 - strike1) * value2 / (value2 - value1))
+                            zero_strikes.append(zero_strike)
+
+                    # Find the closest one to the spot price
+                    if zero_strikes:
+                        zero_strikes = np.array(zero_strikes)
+                        closest_idx = np.argmin(np.abs(zero_strikes - spot_price))
+                        zero_strike = zero_strikes[closest_idx]
+                    else:
+                        zero_strike = None               
+                    
+                    # Net Exposure
+                    net_value = agg_by_strike.sum() * 100
+                    
+                    if not shutil.which("gnuplot"):
+                        print("Please install gnuplot to use this plot.")
+                        return
+                    
+                    gnu = Gnuplot()
+                    
+                    tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".dat")
+                    with open(tmp.name, "w") as f:
+                        for strike, exposure in zip(df_agg.index, agg_by_strike):
+                            f.write(f"{strike} {exposure}\n")
+
+                    strikes = df_agg.index.to_numpy()
+                    step = strikes[1] - strikes[0] if len(strikes) > 1 else 1
+                    boxwidth = step * 0.9
+
+                    # Set up gnuplot
+                    gnu.set(
+                        terminal=terminal,
+                        style="fill solid",
+                        boxwidth=f"{boxwidth} absolute",
+                        border="3 lc rgb 'white'",
+                        title=f'"{name} Exposure by Strike" textcolor rgb "white"',
+                        xtics="textcolor rgb 'white'",
+                        ytics="textcolor rgb 'white'",
+                        grid="xtics ytics lc rgb 'black'",
+                        xrange=f"[{strikes.min()-step}:{strikes.max()+step}]",
+                        object="rectangle from screen 0,0 to screen 1,1 behind fc rgb 'black' fillstyle solid 1.0",
+                    )   
+            
+                    # Horizontal line on 0
+                    gnu.cmd("set arrow from graph 0, first 0 to graph 1, first 0 nohead lc rgb 'white' lw 1")
+
+                    # Spot price
+                    gnu.cmd(f"set arrow from {spot_price}, graph 0 to {spot_price}, graph 1 nohead lc rgb '#C0C0C0' lw 0.9 dt 2")
+                    gnu.cmd(f"set label 'Spot price: {spot_price:.2f}' at graph 0.02, graph 0.79 tc rgb '#C0C0C0'")
+
+                    if not pd.isna(max_positive_strike):
+                        gnu.cmd(
+                            f"set arrow from {max_positive_strike}, graph 0 to {max_positive_strike}, graph 1 nohead lc rgb '#00e400' lw 1.2 dt 2"
+                        )
+                        gnu.cmd(f"set label 'Max: {max_positive_strike:.2f}' at graph 0.02, graph 0.83 tc rgb '#00e400'")
+                    if not pd.isna(max_negative_strike):
+                        gnu.cmd(
+                            f"set arrow from {max_negative_strike}, graph 0 to {max_negative_strike}, graph 1 nohead lc rgb '#da0000' lw 1.2 dt 2"
+                        )
+                        gnu.cmd(f"set label 'Min: {max_negative_strike:.2f}' at graph 0.02, graph 0.87 tc rgb '#da0000'")
+
+
+                    if zero_strike is not None:
+                        gnu.cmd(f"set arrow from {zero_strike}, graph 0 to {zero_strike}, graph 1 nohead lc rgb '#eeee00' lw 1.2 dt 2")
+                        gnu.cmd(f"set label 'Flip: {zero_strike:.2f}' at graph 0.02, graph 0.91 tc rgb '#eeee00'")
+                        
+                    net_color = "#00e400" if net_value > 0 else "#da0000" if net_value < 0 else "white"
+                    gnu.cmd(f"set label 'Net {name}: {net_value:,.2f}' at graph 0.02, graph 0.95 tc rgb '{net_color}'")
+
+                    # Plot
+                    os.system(clear)
+                    gnu.plot(f"'{tmp.name}' using ($1+{boxwidth/2}):2 with boxes lc rgb '#7bbad7' notitle")
+
+                    if save:
+                        # Save as PNG
+                        os.makedirs(os.path.dirname(filename), exist_ok=True)
+                        gnu.cmd(f"set terminal pngcairo size 1200,800 enhanced font 'Sans,12' background rgb 'black'")
+                        gnu.cmd(f"set output '{filename}'")
+                        gnu.plot(f"'{tmp.name}' using ($1+{boxwidth/2}):2 with boxes lc rgb '#7bbad7' notitle")
+                        gnu.cmd("set output")  # close and save
+                        filenames.append(filename)
+
+                    input("Press Enter to close...")
+                    os.system(clear)
+                                        
+                elif "Calls/Puts" in value:
+                    value = value.replace('Calls/Puts', 'Calls Puts')
+                    filename = f"{PLOT_DIR}/{ticker}/{exp}/{greek}/{value.replace(' ', '_')}/{timestamp}.png"
+                    agg_by_strike = df_agg[f"total_{name.lower()}"]
+                    
+                    max_positive_strike = agg_by_strike.idxmax()
+                    max_negative_strike = agg_by_strike.idxmin()
+                    
+                    signs = np.sign(agg_by_strike.values)
+
+                    runs = []
+                    if len(signs) > 0:
+                        current_sign = signs[0]
+                        start = 0
+                        for j in range(1, len(signs)):
+                            if signs[j] != current_sign:
+                                runs.append((current_sign, start, j-1))
+                                current_sign = signs[j]
+                                start = j
+                        runs.append((current_sign, start, len(signs)-1))
+
+                    zero_strikes = []
+                    for r in range(1, len(runs)):
+                        prev_run = runs[r-1]
+                        curr_run = runs[r]
+                        prev_len = prev_run[2] - prev_run[1] + 1
+                        curr_len = curr_run[2] - curr_run[1] + 1
+                        if prev_len >= 2 and curr_len >= 2 and prev_run[0] != curr_run[0] and prev_run[0] != 0 and curr_run[0] != 0:
+                            idx1 = prev_run[2]
+                            idx2 = curr_run[1]
+                            strike1 = agg_by_strike.index[idx1]
+                            value1 = agg_by_strike.iloc[idx1]
+                            strike2 = agg_by_strike.index[idx2]
+                            value2 = agg_by_strike.iloc[idx2]
+                            zero_strike = strike2 - ((strike2 - strike1) * value2 / (value2 - value1))
+                            zero_strikes.append(zero_strike)
+                    
+                    if zero_strikes:
+                        zero_strikes = np.array(zero_strikes)
+                        closest_idx = np.argmin(np.abs(zero_strikes - spot_price))
+                        zero_strike = zero_strikes[closest_idx]
+                    else:
+                        zero_strike = None
+
+                    if not shutil.which("gnuplot"):
+                        print("Please install gnuplot to use this plot.")
+                        return
+                    
+                    gnu = Gnuplot()
+
+                    tmp_calls = tempfile.NamedTemporaryFile(delete=False, suffix=".dat")
+                    with open(tmp_calls.name, "w") as f:
+                        for strike, exposure in zip(df_agg.index, df_agg[f"call_{name[:1].lower()}ex"]):
+                            f.write(f"{strike} {exposure}\n")
+
+                    tmp_puts = tempfile.NamedTemporaryFile(delete=False, suffix=".dat")
+                    with open(tmp_puts.name, "w") as f:
+                        for strike, exposure in zip(df_agg.index, df_agg[f"put_{name[:1].lower()}ex"]):
+                            f.write(f"{strike} {exposure}\n")
+
+                    strikes = df_agg.index.to_numpy()
+                    step = strikes[1] - strikes[0] if len(strikes) > 1 else 1
+                    boxwidth = step * 0.9
+
+                    gnu.set(
+                        terminal=terminal,
+                        style="fill solid",
+                        boxwidth=f"{boxwidth} absolute",
+                        border="3 lc rgb 'white'",
+                        title=f'"{name} Calls vs Puts" textcolor rgb "white"',
+                        xtics="textcolor rgb 'white'",
+                        ytics="textcolor rgb 'white'",
+                        grid="xtics ytics lc rgb 'black'",
+                        xrange=f"[{strikes.min()-step}:{strikes.max()+step}]",
+                        object="rectangle from screen 0,0 to screen 1,1 behind fc rgb 'black' fillstyle solid 1.0",
+                    )
+
+                    gnu.cmd("set arrow from graph 0, first 0 to graph 1, first 0 nohead lc rgb 'white' lw 1")
+                    
+                    gnu.cmd(f"set arrow from {spot_price}, graph 0 to {spot_price}, graph 1 nohead lc rgb '#C0C0C0' lw 0.9 dt 2")
+                    gnu.cmd(f"set label 'Spot price: {spot_price:.2f}' at graph 0.02, graph 0.79 tc rgb '#C0C0C0'")
+
+                    if not pd.isna(max_positive_strike):
+                        gnu.cmd(f"set arrow from {max_positive_strike}, graph 0 to {max_positive_strike}, graph 1 nohead lc rgb '#00e400' lw 1.2 dt 2")
+                        gnu.cmd(f"set label 'Max: {max_positive_strike:.2f}' at graph 0.02, graph 0.83 tc rgb '#00e400'")
+
+                    if not pd.isna(max_negative_strike):
+                        gnu.cmd(f"set arrow from {max_negative_strike}, graph 0 to {max_negative_strike}, graph 1 nohead lc rgb '#da0000' lw 1.2 dt 2")
+                        gnu.cmd(f"set label 'Min: {max_negative_strike:.2f}' at graph 0.02, graph 0.87 tc rgb '#da0000'")
+
+                    if zero_strike is not None:
+                        gnu.cmd(f"set arrow from {zero_strike}, graph 0 to {zero_strike}, graph 1 nohead lc rgb '#eeee00' lw 1.2 dt 2")
+                        gnu.cmd(f"set label 'Flip: {zero_strike:.2f}' at graph 0.02, graph 0.91 tc rgb '#eeee00'")
+                    
+                    gnu.cmd(f"set label 'Calls ({name})' at graph 0.02, graph 0.95 tc rgb '#81d581'")
+                    gnu.cmd(f"set label 'Puts ({name})' at graph 0.02, graph 0.99 tc rgb '#e57272'")
+
+                    os.system(clear)
+                    gnu.plot(
+                        f"'{tmp_calls.name}' using ($1+{boxwidth/2}):2 with boxes lc rgb '#81d581' title 'Calls', "
+                        f"'{tmp_puts.name}' using ($1+{boxwidth/2}):2 with boxes lc rgb '#e57272' title 'Puts'"
+                    )
+
+                    if save:
+                        # Save as PNG
+                        os.makedirs(os.path.dirname(filename), exist_ok=True)
+                        gnu.cmd(f"set terminal pngcairo size 1200,800 enhanced font 'Sans,12' background rgb 'black'")
+                        gnu.cmd(f"set output '{filename}'")
+                        gnu.plot(
+                            f"'{tmp_calls.name}' using ($1+{boxwidth/2}):2 with boxes lc rgb '#81d581' title 'Calls', "
+                            f"'{tmp_puts.name}' using ($1+{boxwidth/2}):2 with boxes lc rgb '#e57272' title 'Puts'"
+                        )
+                        gnu.cmd("set output")
+                        filenames.append(filename)
+
+                    input("Press Enter to close...")
+                    os.system(clear)
+
+            except Exception as e:
+                print(f"Error processing {ticker}/{exp}/{greek}/{value}: {e}")
+    return filenames
+         
 
 @plot.command(help="Plot candle chart for the given symbol.", no_args_is_help=True)
 async def stock(
@@ -103,6 +468,9 @@ async def stock(
     width: Annotated[
         CandleType, Option("--width", "-w", help="Interval of time for each candle.")
     ] = CandleType.HALF_HOUR,
+    save: Annotated[
+        bool, Option("--save", "-s", is_flag=True, help="To save the generated plot")
+    ] = False
 ):
     sesh = RenewableSession()
     candles: list[str] = []
@@ -122,7 +490,7 @@ async def stock(
                 if candle.time == ts:
                     break
     candles.sort()
-    gnuplot(sesh, symbol, candles)
+    gnuplot(sesh, symbol, candles, save)
 
 
 @plot.command(help="Plot candle chart for the given symbol.", no_args_is_help=True)
@@ -131,6 +499,9 @@ async def crypto(
     width: Annotated[
         CandleType, Option("--width", "-w", help="Interval of time for each candle.")
     ] = CandleType.HALF_HOUR,
+    save: Annotated[
+        bool, Option("--save", "-s", is_flag=True, help="To save the generated plot")
+    ] = False
 ):
     sesh = RenewableSession()
     symbol = symbol.upper()
@@ -160,7 +531,7 @@ async def crypto(
                 if candle.time == ts:
                     break
     candles.sort()
-    gnuplot(sesh, crypto.symbol, candles)
+    gnuplot(sesh, crypto.symbol, candles, save)
 
 
 @plot.command(help="Plot candle chart for the given symbol.", no_args_is_help=True)
@@ -169,6 +540,9 @@ async def future(
     width: Annotated[
         CandleType, Option("--width", "-w", help="Interval of time for each candle.")
     ] = CandleType.HALF_HOUR,
+    save: Annotated[
+        bool, Option("--save", "-s", is_flag=True, help="To save the generated plot")
+    ] = False
 ):
     sesh = RenewableSession()
     symbol = symbol.upper()
@@ -201,4 +575,73 @@ async def future(
                 if candle.time == ts:
                     break
     candles.sort()
-    gnuplot(sesh, future.symbol, candles)
+    gnuplot(sesh, future.symbol, candles, save)
+
+@plot.command(help="Plot GEX chart for the given symbol.", no_args_is_help=True)
+async def gamma(
+    symbol: str,
+    days: Annotated[
+        int, Option("--dte", "-d", help="Interval of days to calculate de gamma exposure.")
+    ] = 0,
+    save: Annotated[
+        bool, Option("--save", "-s", is_flag=True, help="To save the generated plot")
+    ] = False 
+):
+    sesh = RenewableSession()
+
+    exposure_data = await chain_data_df(symbol, None, days, "gamma", save)
+    filenames = gnu_plot_greeks_histogram(*exposure_data)
+    if save:
+        print("Plots saved in ", filenames)
+
+@plot.command(help="Plot vanna chart for the given symbol.", no_args_is_help=True)
+async def vanna(
+    symbol: str,
+    days: Annotated[
+        int, Option("--dte", "-d", help="Interval of days to calculate de gamma exposure.")
+    ] = 0,
+    save: Annotated[
+        bool, Option("--save", "-s", is_flag=True, help="To save the generated plot")
+    ] = False 
+):
+    sesh = RenewableSession()
+
+    exposure_data = await chain_data_df(symbol, None, days, "vanna", save)
+    filenames = await gnu_plot_greeks_histogram(*exposure_data)
+    if save:
+        print("Plots saved in ", filenames)
+
+@plot.command(help="Plot charm chart for the given symbol.", no_args_is_help=True)
+async def charm(
+    symbol: str,
+    days: Annotated[
+        int, Option("--dte", "-d", help="Interval of days to calculate de charm exposure.")
+    ] = 0,
+    save: Annotated[
+        bool, Option("--save", "-s", is_flag=True, help="To save the generated plot")
+    ] = False 
+):
+    sesh = RenewableSession()
+
+    exposure_data = await chain_data_df(symbol, None, days, "charm", save)
+    filenames = gnu_plot_greeks_histogram(*exposure_data)
+    if save:
+        print("Plots saved in ", filenames)
+
+
+@plot.command(help="Plot charm delta for the given symbol.", no_args_is_help=True)
+async def delta(
+    symbol: str,
+    days: Annotated[
+        int, Option("--dte", "-d", help="Interval of days to calculate de charm exposure.")
+    ] = 0,
+    save: Annotated[
+        bool, Option("--save", "-s", is_flag=True, help="To save the generated plot")
+    ] = False 
+):
+    sesh = RenewableSession()
+
+    exposure_data = await chain_data_df(symbol, None, days, "delta", save)
+    filenames = gnu_plot_greeks_histogram(*exposure_data)
+    if save:
+        print("Plots saved in ", filenames)


### PR DESCRIPTION
Now using the `ttcli plot gamma SPX --dte 0 --save` the program can, inside the terminal using gnuplot, show the gamma exposure of SPX for 0dte. This command works not only for gamma, but also for vanna, charm, and delta. It also works for any given ticker that it's traded in Tastytrade. 

On DTE any number of days can be set to calculate the exposure. -s or --save can be used if the plot rendered in the terminal wants to be saved in a plots/ directory.

<img width="1200" height="800" alt="20251102_083813" src="https://github.com/user-attachments/assets/45d77329-a202-4973-9f52-73ed123c1bfa" />
<img width="1200" height="800" alt="20251102_083813" src="https://github.com/user-attachments/assets/91cdcb67-90ec-4a0b-b73a-2881650c2441" />

In options.py a couple functions were created to recursively fetch all the necessary data of options and its greeks for all the days that wants to be loaded (--dte) and created a pandas data frame with it, so the exposure can be calculated with the modules/.
To calculate the exposure, the modules/ folder contains the statistical functions to do it.

Also added the functionality to save the plots (candles) for a ticker using the -s too.

All this new functionality requires numba, numpy, pandas, exchange_calendars libs, so in the pyproject.toml and the uv.lock have to be added. I don't know how that works, so that yet to be done.