### PR TITLE
Fix P/L calculations

### DIFF
--- a/ttcli/portfolio.py
+++ b/ttcli/portfolio.py
@@ -219,7 +219,7 @@ async def positions(
             ivr = (metrics.tos_implied_volatility_index_rank or 0) * 100
             indicators = get_indicators(today, metrics)
             trade_price = pos.average_open_price
-            pnl = (mark_price - trade_price) * m * pos.multiplier
+            pnl = (mark_price - trade_price) * m * pos.multiplier * pos.quantity
             day_change = mark_price - prev_close(o.symbol)
             pnl_day = day_change * pos.quantity * pos.multiplier * m
         elif pos.instrument_type == InstrumentType.FUTURE_OPTION:
@@ -241,7 +241,7 @@ async def positions(
             )
             ivr = (metrics.tos_implied_volatility_index_rank or 0) * 100
             trade_price = pos.average_open_price
-            pnl = (mark_price - trade_price) * m * pos.multiplier
+            pnl = (mark_price - trade_price) * m * pos.multiplier * pos.quantity
             day_change = mark_price - prev_close(o.symbol)
             pnl_day = day_change * pos.quantity * pos.multiplier * m
         elif pos.instrument_type == InstrumentType.EQUITY:
@@ -257,7 +257,7 @@ async def positions(
             indicators = get_indicators(today, metrics)
             bwd = beta * mark_price * delta / spy
             ivr = (metrics.tos_implied_volatility_index_rank or 0) * 100
-            pnl = mark - pos.average_open_price * pos.quantity * m
+            pnl = (mark - pos.average_open_price * pos.quantity) * m
             trade_price = pos.average_open_price
             day_change = mark_price - prev_close(pos.symbol)
             pnl_day = day_change * pos.quantity * m
@@ -284,7 +284,7 @@ async def positions(
             delta = 0
             bwd = 0
             ivr = None
-            pnl = mark - pos.average_open_price * pos.quantity * m
+            pnl = (mark - pos.average_open_price * pos.quantity) * m
             trade_price = pos.average_open_price
             indicators = ""
             pos.quantity = round(pos.quantity, 2)

--- a/ttcli/portfolio.py
+++ b/ttcli/portfolio.py
@@ -257,7 +257,7 @@ async def positions(
             indicators = get_indicators(today, metrics)
             bwd = beta * mark_price * delta / spy
             ivr = (metrics.tos_implied_volatility_index_rank or 0) * 100
-            pnl = (mark - pos.average_open_price * pos.quantity) * m
+            pnl = (mark - pos.average_open_price) * pos.quantity * m
             trade_price = pos.average_open_price
             day_change = mark_price - prev_close(pos.symbol)
             pnl_day = day_change * pos.quantity * m

--- a/ttcli/portfolio.py
+++ b/ttcli/portfolio.py
@@ -284,7 +284,7 @@ async def positions(
             delta = 0
             bwd = 0
             ivr = None
-            pnl = (mark - pos.average_open_price * pos.quantity) * m
+            pnl = (mark - pos.average_open_price) * pos.quantity * m
             trade_price = pos.average_open_price
             indicators = ""
             pos.quantity = round(pos.quantity, 2)


### PR DESCRIPTION
Total P/L for equity options and futures options was not multiplied by pos.quantity, positions with more than one contract showed per-contract P/L instead of total. Also fixed operator precedence in the equity and cryptocurrency (for completeness only at least at this time) P/L formulas where the direction multiplier m was only applied to the cost basis instead of the whole expression, producing incorrect values for short positions.

Follows up on #27 which fixed the related pnl_day and BWD calculations. Many thanks!